### PR TITLE
hotfix: added curl to alpine image for healthcheck

### DIFF
--- a/dockerfile
+++ b/dockerfile
@@ -11,6 +11,7 @@ RUN go mod tidy && go build -o rivenbot-api-service ./cmd/rivenbot-api-service/m
 
 FROM alpine:latest
 
+RUN apk add --no-cache curl
 WORKDIR /root/
 
 COPY --from=builder /app/rivenbot-api-service .


### PR DESCRIPTION
This small hotfix just adds curl to the alpine version of the docker image since it needs to be able to introspect itself in order for [this task](https://github.com/Riven-of-a-Thousand-Servers/rivenbot-api-service/issues/12) to work